### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/apps/desktop/main.js
+++ b/apps/desktop/main.js
@@ -78,7 +78,14 @@ function createWindow() {
     // If it's an internal URL (like a sub-app or specific auth flow we want in app)
     // but usually for Electron, we want EVERYTHING external to go to system browser
     // to keep the app focused and secure.
-    if (isInternalUrl(url) && !url.includes('accounts.google.com')) {
+    let isGoogleAccountsHost = false;
+    try {
+      isGoogleAccountsHost = new URL(url).hostname === 'accounts.google.com';
+    } catch (e) {
+      isGoogleAccountsHost = false;
+    }
+
+    if (isInternalUrl(url) && !isGoogleAccountsHost) {
       return { action: 'allow' };
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/SmitroniX/DYPU-Connect/security/code-scanning/10](https://github.com/SmitroniX/DYPU-Connect/security/code-scanning/10)

The best fix is to **parse the URL and compare its hostname exactly**, instead of substring-matching the entire URL text.

In `apps/desktop/main.js`, replace the condition on line 81:

- Current: `!url.includes('accounts.google.com')`
- Safer: parse with `new URL(url)` and check `parsedUrl.hostname === 'accounts.google.com'` (or a small helper boolean), with a try/catch fallback that treats malformed URLs as external/denied.

This preserves existing functionality intent: allow internal URLs except Google Accounts auth flows, while avoiding bypasses via query/path/subdomain tricks. No new dependency is required; Node/Electron provides the standard `URL` class globally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
